### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,8 @@
 name: Build & Push Docker Image
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/netgoat-xyz/frontend/security/code-scanning/2](https://github.com/netgoat-xyz/frontend/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block at the workflow root or for the job itself. Since this workflow only checks out code and pushes to Docker Hub (not using GITHUB_TOKEN for uploading build artifacts or modifying repository state), it only requires read access to repository contents. The best-practice fix is to add `permissions: contents: read` directly at the workflow root (top-level, before or after `on:`) in `.github/workflows/docker-build.yml`. No other changes, imports, or definitions are required, and this addition will not affect the workflow's existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
